### PR TITLE
Payload no request

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash.takeright": "^4.1.1",
     "lodash.throttle": "^4.1.1",
     "lodash.times": "^4.3.2",
+    "lodash.get": "^4.3.2",
     "sift": "^3.2.7",
     "uuid": "^3.0.1"
   }

--- a/src/components/PowerTable/index.js
+++ b/src/components/PowerTable/index.js
@@ -208,6 +208,7 @@ class PowerTable extends React.Component {
    */
   _onApplyFilter(perValue, perConditions, dataInfo) {
     this.worker.postMessage({ action: 'FILTER', perValue, perConditions, dataInfo});
+    this._selectColumn(null);
   }
 
   /**
@@ -244,6 +245,7 @@ class PowerTable extends React.Component {
    */
   _sort(direction, dataKey) {
     this.worker.postMessage({ action: 'SORT', direction, dataKey});
+    this._selectColumn(null);
   }
 
 
@@ -288,7 +290,7 @@ class PowerTable extends React.Component {
       <div>
         <p>{this.state.message || ' '}</p>
         <div className='PWT-TableHeader' style={{backgroundColor: '#f3f3f3'}}>
-          <table className='sv-table with--hover with--grid' style={{tableLayout: 'fixed'}}>
+          <table className='sv-table with--borders' style={{tableLayout: 'fixed'}}>
             <thead>
             <tr>
               {headers}
@@ -302,7 +304,7 @@ class PowerTable extends React.Component {
             onNextPage={this._paginate}
             onPreviousPage={this._paginate}
             onSelectASpecifPage={this._paginate}
-            recordsByPage={16}
+            recordsByPage={this.props.itensInViewPort}
             ref='paginate'
             totalSizeOfData={this.state.count}
           />

--- a/src/components/PowerTable/index.js
+++ b/src/components/PowerTable/index.js
@@ -43,10 +43,11 @@ class PowerTable extends React.Component {
 
     let _message = {
       action: 'LOAD',
-      url: 'http://localhost:9000/data_collection-1.1.6.js',
-      dataUrl: this.props.dataUrl,
+      fetchUrl: this.props.fetchUrl,
       fetchMethod: this.props.fetchMethod,
-      pageSize: this.props.itensInViewPort,
+      fetchParams: this.props.fetchParams,
+      responseCollectionPath: this.props.responseCollectionPath,
+      pageSize: this.props.pageSize,
       cols: this.columns.map((col) => {
         if(col.key) {
           return {key: col.key, searchable: col.searchable};
@@ -255,7 +256,7 @@ class PowerTable extends React.Component {
       collection: this.state.collection,
       columns: this.columns,
       container: this.node,
-      itensInViewPort: this.props.itensInViewPort,
+      pageSize: this.props.pageSize,
       onScroll: this._paginate,
       rowHeight: this.props.rowHeight,
       totalRecords: this.state.count,
@@ -304,7 +305,7 @@ class PowerTable extends React.Component {
             onNextPage={this._paginate}
             onPreviousPage={this._paginate}
             onSelectASpecifPage={this._paginate}
-            recordsByPage={this.props.itensInViewPort}
+            recordsByPage={this.props.pageSize}
             ref='paginate'
             totalSizeOfData={this.state.count}
           />
@@ -322,11 +323,12 @@ PowerTable.defaultProps = {
 };
 
 PowerTable.propTypes = {
-  dataUrl: React.PropTypes.string.isRequired,
+  fetchUrl: React.PropTypes.string.isRequired,
   fetchMethod: React.PropTypes.oneOf(['GET', 'POST']),
   fetchParams: React.PropTypes.object,
+  responseCollectionPath: React.PropTypes.string,
   groupBy: React.PropTypes.string,
-  itensInViewPort: React.PropTypes.number.isRequired,
+  pageSize: React.PropTypes.number.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2308,6 +2308,10 @@ lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
 
+lodash.get@^4.3.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.groupby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"


### PR DESCRIPTION
Mudanças:

1. Passagem de um payload JSON no request
2. ResultExtractor: Possibilidade de indicar o path da collection (relativo ao response) a ser carregada no PowerTable. O ideal seria o PowerTable receber uma função responsável por essa extração. Porém, não é possível passar uma function para o Worker... eu tentei... então estou passando apenas um path e usando o _.get para recuperar a collection a partir do response. 

Mergear o PR #10 antes deste deve tornar o review mais fácil. 